### PR TITLE
#3 - Update deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Upload artifacts
       uses: actions/upload-pages-artifact@v3
       with:
-        path: dist/demo
+        path: ngx-mat-table-toolkit/dist/demo
 
     - name: Deploy to GitHub Pages
       id: deployment


### PR DESCRIPTION
- Updated path to `ngx-mat-table-toolkit/dist/demo` because after debugging previous 404 deployment, it seems to look for ngx-mat-table-toolkit/ngx-mat-table-toolkit/dist/demo for the artifacts..