### PR TITLE
#63 - Update generic on configs in table component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [0.20.0](https://github.com/admcfarland/ngx-mat-table-toolkit/compare/v0.19.2...v0.20.0) (2025-04-02)
+
+
+### ⚠ BREAKING CHANGES
+
+* add missing generic to ColumnsConfig and RowActionsConfig usages
+
+### Features
+
+* update missing configs utilizing generic ([f9bb09f](https://github.com/admcfarland/ngx-mat-table-toolkit/commit/f9bb09f8140625a30436c777423d6a60c6a7b664)), closes [#63](https://github.com/admcfarland/ngx-mat-table-toolkit/issues/63)
+
 ### [0.19.2](https://github.com/admcfarland/ngx-mat-table-toolkit/compare/v0.19.1...v0.19.2) (2025-04-02)
 
 ### [0.19.1](https://github.com/admcfarland/ngx-mat-table-toolkit/compare/v0.19.0...v0.19.1) (2025-04-02)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ngx-mat-table-toolkit",
-  "version": "0.19.2",
+  "version": "0.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ngx-mat-table-toolkit",
-      "version": "0.19.2",
+      "version": "0.20.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^17.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-mat-table-toolkit",
-  "version": "0.19.2",
+  "version": "0.20.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/projects/ngx-mat-table-toolkit/src/lib/mtt-table/child-components/mtt-modify-columns/mtt-modify-columns.ts
+++ b/projects/ngx-mat-table-toolkit/src/lib/mtt-table/child-components/mtt-modify-columns/mtt-modify-columns.ts
@@ -47,12 +47,12 @@ export class MttModifyColumns implements OnInit {
   /**
    * Observable for column configuration.
    */
-  columnConfig$ = new Observable<ColumnsConfig>();
+  columnConfig$ = new Observable<ColumnsConfig<any>>();
 
   /**
    * Column configuration.
    */
-  protected config!: ColumnsConfig;
+  protected config!: ColumnsConfig<any>;
 
   /**
    * Modified columns.

--- a/projects/ngx-mat-table-toolkit/src/lib/mtt-table/models/table.model.ts
+++ b/projects/ngx-mat-table-toolkit/src/lib/mtt-table/models/table.model.ts
@@ -24,7 +24,7 @@ export interface TableConfig<T> {
   /**
    * Configuration for table columns.
    */
-  columnsConfig: ColumnsConfig;
+  columnsConfig: ColumnsConfig<T>;
 
   /**
    * Configuration for table rows.
@@ -54,7 +54,7 @@ export interface TableConfig<T> {
   /**
    * Configuration for actions available on individual rows.
    */
-  rowActions?: RowActionsConfig;
+  rowActions?: RowActionsConfig<T>;
 
   /**
    * Configuration for the table's search bar filter.


### PR DESCRIPTION
- After generics were added to ColumnsConfig and RowActionsConfig, it was missed to add the generic where these interfaces where being utilized 