### PR TITLE
#47 - CSS variables are not exported to npm package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.20.1](https://github.com/admcfarland/ngx-mat-table-toolkit/compare/v0.20.0...v0.20.1) (2025-04-02)
+
 ## [0.20.0](https://github.com/admcfarland/ngx-mat-table-toolkit/compare/v0.19.2...v0.20.0) (2025-04-02)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ngx-mat-table-toolkit",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ngx-mat-table-toolkit",
-      "version": "0.20.0",
+      "version": "0.20.1",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^17.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-mat-table-toolkit",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/projects/ngx-mat-table-toolkit/ng-package.json
+++ b/projects/ngx-mat-table-toolkit/ng-package.json
@@ -3,5 +3,8 @@
   "dest": "../../dist/ngx-mat-table-toolkit",
   "lib": {
     "entryFile": "src/public-api.ts"
-  }
+  },
+  "assets": [
+    "./src/lib/styles/variables.scss"
+  ]
 }

--- a/projects/ngx-mat-table-toolkit/src/lib/styles/variables.scss
+++ b/projects/ngx-mat-table-toolkit/src/lib/styles/variables.scss
@@ -1,0 +1,21 @@
+:root {
+  --mtt-form-field-font-size: .875rem;
+
+  --mtt-search-bar-width: 37.5rem;
+
+  --mtt-header-row-height: 2.5625rem;
+  --mtt-header-row-background-color: #eeeeee;
+
+  --mtt-row-height: 2.25rem;
+  --mtt-row-hover-odd-background-color: #dddddd;
+  --mtt-row-hover-even-background-color: #d0d0d0;
+  --mtt-row-zebra-odd-background-color: var(--mat-app-background-color, transparent);
+  --mtt-row-zebra-even-background-color: #eeeeee;
+
+  --mtt-action-column-sticky-left-border: #b4b5bb;
+
+  --mtt-paginator-height: 3.5rem;
+  --mtt-paginator-mat-form-field-height: 2.5625rem;
+  --mtt-paginator-range-actions-height: 2.5rem;
+  --mtt-paginator-font-size: .875rem;
+}


### PR DESCRIPTION
- Added `styles/variables.scss` to lib for exporting css root variables