### PR TITLE
#68 - Require config as input on MttTable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [0.22.0](https://github.com/admcfarland/ngx-mat-table-toolkit/compare/v0.21.0...v0.22.0) (2025-04-02)
+
+
+### ⚠ BREAKING CHANGES
+
+* config is now a required @Input of MttTable since it is useless without one
+
+### Features
+
+* require config input ([7658e14](https://github.com/admcfarland/ngx-mat-table-toolkit/commit/7658e1430d37042db7a842a7ee3e69c0b8f1ebde)), closes [#68](https://github.com/admcfarland/ngx-mat-table-toolkit/issues/68)
+
 ## [0.21.0](https://github.com/admcfarland/ngx-mat-table-toolkit/compare/v0.20.1...v0.21.0) (2025-04-02)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ngx-mat-table-toolkit",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ngx-mat-table-toolkit",
-      "version": "0.21.0",
+      "version": "0.22.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^17.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-mat-table-toolkit",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/projects/ngx-mat-table-toolkit/src/lib/mtt-table/mtt-table.ts
+++ b/projects/ngx-mat-table-toolkit/src/lib/mtt-table/mtt-table.ts
@@ -87,7 +87,7 @@ export class MttTable<T> implements OnChanges, OnInit, OnDestroy {
   /**
    * Table configuration.
    */
-  @Input() config!: TableConfig<T>;
+  @Input({ required: true }) config!: TableConfig<T>;
 
   /**
    * Data to be displayed in the table.


### PR DESCRIPTION
- Requiring `@Input config` since MttTable is useless without it